### PR TITLE
Add config option to enable/disable tracking metrics

### DIFF
--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -46,6 +46,8 @@ class AppConfig(BaseModel):
         file_uploads_allowed_extensions: Allowed file extensions. `['.*']` allows all.
         cli_multiline_input: Whether to enable multiline input in CLI. When disabled,
             input is read line by line. When enabled, input continues until /exit command.
+        conversation_max_age_seconds: Maximum age of a conversation in seconds.
+        track_llm_metrics: Whether to track LLM metrics for display in the web UI (cost, latency, token usage).
     """
 
     llms: dict[str, LLMConfig] = Field(default_factory=dict)
@@ -82,6 +84,7 @@ class AppConfig(BaseModel):
     daytona_target: str = Field(default='us')
     cli_multiline_input: bool = Field(default=False)
     conversation_max_age_seconds: int = Field(default=864000)  # 10 days in seconds
+    track_llm_metrics: bool = Field(default=False)
 
     defaults_dict: ClassVar[dict] = {}
 

--- a/openhands/core/setup.py
+++ b/openhands/core/setup.py
@@ -164,6 +164,7 @@ def create_controller(
         headless_mode=headless_mode,
         confirmation_mode=config.security.confirmation_mode,
         replay_events=replay_events,
+        track_llm_metrics=config.track_llm_metrics,
     )
     return (controller, initial_state)
 

--- a/openhands/server/session/agent_session.py
+++ b/openhands/server/session/agent_session.py
@@ -124,6 +124,7 @@ class AgentSession:
                 max_budget_per_task=max_budget_per_task,
                 agent_to_llm_config=agent_to_llm_config,
                 agent_configs=agent_configs,
+                track_llm_metrics=config.track_llm_metrics,
             )
             if github_token:
                 self.event_stream.set_secrets(
@@ -285,6 +286,7 @@ class AgentSession:
         max_budget_per_task: float | None = None,
         agent_to_llm_config: dict[str, LLMConfig] | None = None,
         agent_configs: dict[str, AgentConfig] | None = None,
+        track_llm_metrics: bool = False,
     ) -> AgentController:
         """Creates an AgentController instance
 
@@ -330,6 +332,7 @@ class AgentSession:
             headless_mode=False,
             status_callback=self._status_callback,
             initial_state=self._maybe_restore_state(),
+            track_llm_metrics=track_llm_metrics,
         )
 
         return controller


### PR DESCRIPTION
**Give a summary of what the PR does, explaining any non-trivial design decisions.**

@AutoLTX What do you think about a configuration option to enable/disable? 

Please take a look at this PR. I tested running both via `agent_session` and via `main.py`. 😄 

With `make run`, it can be in config.toml or as an environment variable. With `docker run`, as environment variable.